### PR TITLE
Add push_path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ This action compiles latex/xelatex files using [Tectonic](https://tectonic-types
 
 **Optional** Compiled PDF is pushed, if `push` is passed as 'yes'.
 
+### `push_path`
+
+**Optional** Path to push compiled PDF to, if defined.
+
 ## Outputs
-Pushes a Compiled PDF file parallel to the tex, xtx file, if push is passed as 'yes'.
+Pushes a Compiled PDF file parallel to the tex, xtx file, if push is passed as 'yes' and push_path is undefined. Otherwise a Compiled PDF file will be pushed to the location defined in push_path, if push is passed as 'yes'.
 
 ## Example usage
 
@@ -34,6 +38,7 @@ jobs:
       with:
         tex_path: 'dir/file.tex'
         push: 'yes'
+        push_path: 'output_dir'
 ```
 
 ### Doesn't Push Compiled PDF

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,13 @@ inputs:
     description: 'String stating whether to push output PDF, PDF will only be pushed in case of "yes"'
     default: 'no'
     required: false
+  push_path:
+    description: 'Path of output PDF, PDF will be pushed to same directory as Tex File if unused'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.tex_path }}
     - ${{ inputs.push }}
+    - ${{ inputs.push_path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,16 @@ fi
 
 FILE_NAME=$(basename $OUTPUT_PDF)
 DIR=$(dirname $OUTPUT_PDF)
+OUTPUT_PATH=$OUTPUT_PDF
+
+PUSH_PATH=$3
+if [[ ! -z $PUSH_PATH ]]; then
+  if [[ ${PUSH_PATH:0:1} == "/" ]]; then
+    PUSH_PATH=${PUSH_PATH:1}
+  fi
+  DIR=$PUSH_PATH
+  OUTPUT_PATH="$DIR/$FILE_NAME"
+fi
 
 STATUSCODE=$(curl --silent --output resp.json --write-out "%{http_code}" -X GET -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/$DIR)
 
@@ -34,11 +44,11 @@ do
     if [ "$NAME" = "$FILE_NAME" ]; then
         SHA=$(echo $i | jq -r .sha)
         break
-    fi    
+    fi
 done
 
 echo '{
-  "message": "'"update $OUTPUT_PDF"'",
+  "message": "'"update $OUTPUT_PATH"'",
   "committer": {
     "name": "Tectonic Action",
     "email": "tectonic-action@github.com"
@@ -49,7 +59,7 @@ echo '{
 
 STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" \
             -i -X PUT -H "Authorization: token $GITHUB_TOKEN" -d @payload.json \
-            https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/${OUTPUT_PDF})
+            https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/${OUTPUT_PATH})
 
 if [ $((STATUSCODE/100)) -ne 2 ]; then
   echo "Github's API returned $STATUSCODE"


### PR DESCRIPTION
If the push_path argument is defined, the output PDF will be pushed to this location instead of parallel to the .tex file